### PR TITLE
Update keydocs.en.adoc

### DIFF
--- a/keydocs.en.adoc
+++ b/keydocs.en.adoc
@@ -110,7 +110,7 @@ Querying the IUCN Red List, using a species list, OpenRefine, and some pre-writt
 
 === Planning/Collaboration
 
-* http://www.agilenutshell.com/[Agile^]
+* https://softailed.com/blog/benefits-of-agile-methodology[Benefits of the Agile Methodology^]
 * https://www.scrum.org/resources/what-is-scrum[What is SCRUM^]
 * https://www.atlassian.com/agile/scrum[SCRUM Framework^]
 * https://www.atlassian.com/agile/kanban[Kanban methodology^]


### PR DESCRIPTION
The 'Agile' source explaining the logic behind the methodology is no longer available. I have replaced it with another explanatory article.